### PR TITLE
fix - Remove sqlite from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ Requests==2.32.3
 sqlite_vec==0.1.6
 tqdm==4.66.5
 ultralytics==8.3.5
-sqlite==3.45.3


### PR DESCRIPTION
Sqlite3 is already part of python stdlib not needed in the requirements. https://docs.python.org/3/library/sqlite3.html